### PR TITLE
fix(link): modify abnormal operation of the link()

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -282,7 +282,10 @@ angular.module('ngMeditor')
                 function link() {
                     var LINKY_URL_REGEXP =
                         /((ftp|https?):\/\/|(www\.)|(mailto:)?[A-Za-z0-9._%+-]+@)\S*[^\s.;,(){}<>"”’]$/;
-                    var sub = selection.anchorNode.data.substring(0, selection.anchorOffset - 1);
+                    var sub = '';
+                    if (selection.anchorNode.data) {
+                      sub = selection.anchorNode.data.substring(0, selection.anchorOffset - 1);
+                    }
                     if (LINKY_URL_REGEXP.test(sub)) {
                         var matchs = sub.match(LINKY_URL_REGEXP);
                         if (matchs && matchs.length) {
@@ -351,7 +354,9 @@ angular.module('ngMeditor')
                     //code ```
                     if (evt.which === 192) code();
                     //link
-                    if (evt.which === 32) link();
+                    if ((!evt.ctrlKey && !evt.shiftKey) && evt.which === 32) {
+                      link();
+                    }
                 };
 
                 scope.doMouseup = function() {


### PR DESCRIPTION
When there is no text on that line if the space key while the shift key or the ctrl key pressed pressed, an error occurs as follows.

TypeError: Cannot read property 'substring' of undefined
    at link (http://cdn.rawgit.com/icattlecoder/ngMeditor/master/src/editor.js:285:56)
    at k.scope.doKeyup (http://cdn.rawgit.com/icattlecoder/ngMeditor/master/src/editor.js:354:43)

So, modify and test the result of the logic part scope.doKeyup()
But significantly reduced the error
event binding point is that the same error occurred intermittently displaced.

So, link() function to modify the internal logic was to test results work well.
